### PR TITLE
Feature add login logout page

### DIFF
--- a/client/src/pages/Login/Login.tsx
+++ b/client/src/pages/Login/Login.tsx
@@ -41,7 +41,7 @@ export default function Login(): JSX.Element {
       <Grid item xs={12} sm={8} md={7} elevation={6} component={Paper} className={classes.wrapper}>
         <Box width="100%" maxWidth={450} p={3} mt={5}>
           <Grid container justify="center" alignItems="center">
-            <Typography className={classes.welcome} component="h1">
+            <Typography className={classes.welcome} component="h1" color="textPrimary">
               Welcome back!
             </Typography>
           </Grid>

--- a/client/src/pages/Login/Login.tsx
+++ b/client/src/pages/Login/Login.tsx
@@ -37,18 +37,15 @@ export default function Login(): JSX.Element {
   };
 
   return (
-    <Grid container component="main" className={classes.root}>
+    <Grid container component="main" className={classes.root} justify="center" alignItems="center">
       <CssBaseline />
-      <Grid item xs={12} sm={8} md={7} elevation={6} component={Paper} square>
+      <Grid item xs={12} sm={8} md={7} elevation={6} component={Paper} style={{ height: '80vh', minHeight: '40rem' }}>
         <Box className={classes.authWrapper}>
-          <AuthHeader linkTo="/signup" asideText="Don't have an account?" btnText="Create account" />
           <Box width="100%" maxWidth={450} p={3} alignSelf="center">
-            <Grid container>
-              <Grid item xs>
-                <Typography className={classes.welcome} component="h1" variant="h5">
-                  Welcome back!
-                </Typography>
-              </Grid>
+            <Grid container justify="center" alignItems="center">
+              <Typography className={classes.welcome} component="h1">
+                Welcome back!
+              </Typography>
             </Grid>
             <LoginForm handleSubmit={handleSubmit} />
           </Box>

--- a/client/src/pages/Login/Login.tsx
+++ b/client/src/pages/Login/Login.tsx
@@ -7,7 +7,6 @@ import Typography from '@material-ui/core/Typography';
 import useStyles from './useStyles';
 import login from '../../helpers/APICalls/login';
 import LoginForm from './LoginForm/LoginForm';
-import AuthHeader from '../../components/AuthHeader/AuthHeader';
 import { useAuth } from '../../context/useAuthContext';
 import { useSnackBar } from '../../context/useSnackbarContext';
 
@@ -39,17 +38,14 @@ export default function Login(): JSX.Element {
   return (
     <Grid container component="main" className={classes.root} justify="center" alignItems="center">
       <CssBaseline />
-      <Grid item xs={12} sm={8} md={7} elevation={6} component={Paper} style={{ height: '80vh', minHeight: '40rem' }}>
-        <Box className={classes.authWrapper}>
-          <Box width="100%" maxWidth={450} p={3} alignSelf="center">
-            <Grid container justify="center" alignItems="center">
-              <Typography className={classes.welcome} component="h1">
-                Welcome back!
-              </Typography>
-            </Grid>
-            <LoginForm handleSubmit={handleSubmit} />
-          </Box>
-          <Box p={1} alignSelf="center" />
+      <Grid item xs={12} sm={8} md={7} elevation={6} component={Paper} className={classes.wrapper}>
+        <Box width="100%" maxWidth={450} p={3} mt={5}>
+          <Grid container justify="center" alignItems="center">
+            <Typography className={classes.welcome} component="h1">
+              Welcome back!
+            </Typography>
+          </Grid>
+          <LoginForm handleSubmit={handleSubmit} />
         </Box>
       </Grid>
     </Grid>

--- a/client/src/pages/Login/LoginForm/LoginForm.tsx
+++ b/client/src/pages/Login/LoginForm/LoginForm.tsx
@@ -48,7 +48,9 @@ export default function Login({ handleSubmit }: Props): JSX.Element {
       {({ handleSubmit, handleChange, values, touched, errors, isSubmitting }) => (
         <form onSubmit={handleSubmit} className={classes.form} noValidate>
           <InputLabel htmlFor="email">
-            <Typography className={classes.label}>E-MAIL ADDRESS</Typography>
+            <Typography className={classes.label} color="textPrimary">
+              e-mail address
+            </Typography>
           </InputLabel>
           <TextField
             id="email"
@@ -71,7 +73,9 @@ export default function Login({ handleSubmit }: Props): JSX.Element {
             variant="outlined"
           />
           <InputLabel htmlFor="password">
-            <Typography className={classes.label}>PASSWORD</Typography>
+            <Typography className={classes.label} color="textPrimary">
+              password
+            </Typography>
           </InputLabel>
           <TextField
             id="password"
@@ -83,7 +87,6 @@ export default function Login({ handleSubmit }: Props): JSX.Element {
             }}
             InputProps={{
               classes: { input: classes.inputs },
-              // endAdornment: <Typography className={classes.forgot}>Forgot?</Typography>,
             }}
             type="password"
             autoComplete="current-password"
@@ -95,11 +98,11 @@ export default function Login({ handleSubmit }: Props): JSX.Element {
           />
           <Box textAlign="center">
             <Button type="submit" size="large" variant="contained" color="secondary" className={classes.submit}>
-              {isSubmitting ? <CircularProgress style={{ color: 'white' }} /> : 'Login'}
+              {isSubmitting ? <CircularProgress className={classes.circleColor} /> : 'Login'}
             </Button>
           </Box>
           <Box mt={3} textAlign="center" alignItems="center" justifyContent="center">
-            <Typography style={{ fontWeight: 'bold' }}> Don&apos;t have account? </Typography>
+            <Typography className={classes.boldText}> Don&apos;t have account? </Typography>
             <NavLink to="/signup" color="secondary">
               <Typography color="secondary">Create an account</Typography>
             </NavLink>

--- a/client/src/pages/Login/LoginForm/LoginForm.tsx
+++ b/client/src/pages/Login/LoginForm/LoginForm.tsx
@@ -99,7 +99,7 @@ export default function Login({ handleSubmit }: Props): JSX.Element {
             </Button>
           </Box>
           <Box mt={3} textAlign="center" alignItems="center" justifyContent="center">
-            <Typography> Don&apos;t have account? </Typography>
+            <Typography style={{ fontWeight: 'bold' }}> Don&apos;t have account? </Typography>
             <NavLink to="/signup" color="secondary">
               <Typography color="secondary">Create an account</Typography>
             </NavLink>

--- a/client/src/pages/Login/LoginForm/LoginForm.tsx
+++ b/client/src/pages/Login/LoginForm/LoginForm.tsx
@@ -5,7 +5,7 @@ import { Formik, FormikHelpers } from 'formik';
 import * as Yup from 'yup';
 import Typography from '@material-ui/core/Typography';
 import useStyles from './useStyles';
-import { CircularProgress } from '@material-ui/core';
+import { CircularProgress, InputLabel } from '@material-ui/core';
 
 interface Props {
   handleSubmit: (
@@ -46,9 +46,12 @@ export default function Login({ handleSubmit }: Props): JSX.Element {
     >
       {({ handleSubmit, handleChange, values, touched, errors, isSubmitting }) => (
         <form onSubmit={handleSubmit} className={classes.form} noValidate>
+          <InputLabel htmlFor="email">
+            <Typography className={classes.label}>E-MAIL ADDRESS</Typography>
+          </InputLabel>
           <TextField
             id="email"
-            label={<Typography className={classes.label}>E-mail address</Typography>}
+            placeholder="Your email"
             fullWidth
             margin="normal"
             InputLabelProps={{
@@ -64,10 +67,14 @@ export default function Login({ handleSubmit }: Props): JSX.Element {
             error={touched.email && Boolean(errors.email)}
             value={values.email}
             onChange={handleChange}
+            variant="outlined"
           />
+          <InputLabel htmlFor="password">
+            <Typography className={classes.label}>Password</Typography>
+          </InputLabel>
           <TextField
             id="password"
-            label={<Typography className={classes.label}>Password</Typography>}
+            placeholder="Password"
             fullWidth
             margin="normal"
             InputLabelProps={{
@@ -75,7 +82,7 @@ export default function Login({ handleSubmit }: Props): JSX.Element {
             }}
             InputProps={{
               classes: { input: classes.inputs },
-              endAdornment: <Typography className={classes.forgot}>Forgot?</Typography>,
+              // endAdornment: <Typography className={classes.forgot}>Forgot?</Typography>,
             }}
             type="password"
             autoComplete="current-password"
@@ -83,13 +90,13 @@ export default function Login({ handleSubmit }: Props): JSX.Element {
             error={touched.password && Boolean(errors.password)}
             value={values.password}
             onChange={handleChange}
+            variant="outlined"
           />
           <Box textAlign="center">
-            <Button type="submit" size="large" variant="contained" color="primary" className={classes.submit}>
+            <Button type="submit" size="large" variant="contained" color="secondary" className={classes.submit}>
               {isSubmitting ? <CircularProgress style={{ color: 'white' }} /> : 'Login'}
             </Button>
           </Box>
-          <div style={{ height: 95 }} />
         </form>
       )}
     </Formik>

--- a/client/src/pages/Login/LoginForm/LoginForm.tsx
+++ b/client/src/pages/Login/LoginForm/LoginForm.tsx
@@ -102,7 +102,7 @@ export default function Login({ handleSubmit }: Props): JSX.Element {
             </Button>
           </Box>
           <Box mt={3} textAlign="center" alignItems="center" justifyContent="center">
-            <Typography className={classes.boldText}> Don&apos;t have account? </Typography>
+            <Typography className={classes.boldText}> {"Don't have account? "}</Typography>
             <NavLink to="/signup" color="secondary">
               <Typography color="secondary">Create an account</Typography>
             </NavLink>

--- a/client/src/pages/Login/LoginForm/LoginForm.tsx
+++ b/client/src/pages/Login/LoginForm/LoginForm.tsx
@@ -71,7 +71,7 @@ export default function Login({ handleSubmit }: Props): JSX.Element {
             variant="outlined"
           />
           <InputLabel htmlFor="password">
-            <Typography className={classes.label}>Password</Typography>
+            <Typography className={classes.label}>PASSWORD</Typography>
           </InputLabel>
           <TextField
             id="password"

--- a/client/src/pages/Login/LoginForm/LoginForm.tsx
+++ b/client/src/pages/Login/LoginForm/LoginForm.tsx
@@ -6,6 +6,7 @@ import * as Yup from 'yup';
 import Typography from '@material-ui/core/Typography';
 import useStyles from './useStyles';
 import { CircularProgress, InputLabel } from '@material-ui/core';
+import { NavLink } from 'react-router-dom';
 
 interface Props {
   handleSubmit: (
@@ -96,6 +97,12 @@ export default function Login({ handleSubmit }: Props): JSX.Element {
             <Button type="submit" size="large" variant="contained" color="secondary" className={classes.submit}>
               {isSubmitting ? <CircularProgress style={{ color: 'white' }} /> : 'Login'}
             </Button>
+          </Box>
+          <Box mt={3} textAlign="center" alignItems="center" justifyContent="center">
+            <Typography> Don&apos;t have account? </Typography>
+            <NavLink to="/signup" color="secondary">
+              <Typography color="secondary">Create an account</Typography>
+            </NavLink>
           </Box>
         </form>
       )}

--- a/client/src/pages/Login/LoginForm/useStyles.ts
+++ b/client/src/pages/Login/LoginForm/useStyles.ts
@@ -6,8 +6,10 @@ const useStyles = makeStyles((theme) => ({
     marginTop: theme.spacing(1),
   },
   label: {
+    position: 'relative',
+    top: '1rem',
     color: 'rgb(0,0,0)',
-    fontWeight: theme.typography.fontWeightBold,
+    fontWeight: 900,
   },
   inputs: {
     height: '1rem',

--- a/client/src/pages/Login/LoginForm/useStyles.ts
+++ b/client/src/pages/Login/LoginForm/useStyles.ts
@@ -6,17 +6,13 @@ const useStyles = makeStyles((theme) => ({
     marginTop: theme.spacing(1),
   },
   label: {
+    textTransform: 'uppercase',
     position: 'relative',
     top: '1rem',
-    color: 'rgb(0,0,0)',
     fontWeight: 900,
   },
   inputs: {
     height: '1rem',
-  },
-  forgot: {
-    paddingRight: 10,
-    color: '#3a8dff',
   },
   submit: {
     margin: theme.spacing(3, 2, 2),
@@ -27,6 +23,12 @@ const useStyles = makeStyles((theme) => ({
     marginTop: 49,
     fontSize: 16,
     fontWeight: 'bold',
+  },
+  boldText: {
+    fontWeight: 'bold',
+  },
+  circleColor: {
+    color: 'white',
   },
 }));
 

--- a/client/src/pages/Login/LoginForm/useStyles.ts
+++ b/client/src/pages/Login/LoginForm/useStyles.ts
@@ -6,14 +6,11 @@ const useStyles = makeStyles((theme) => ({
     marginTop: theme.spacing(1),
   },
   label: {
-    fontSize: 19,
-    color: 'rgb(0,0,0,0.4)',
-    paddingLeft: '5px',
+    color: 'rgb(0,0,0)',
+    fontWeight: theme.typography.fontWeightBold,
   },
   inputs: {
-    marginTop: '.8rem',
-    height: '2rem',
-    padding: '5px',
+    height: '1rem',
   },
   forgot: {
     paddingRight: 10,
@@ -27,7 +24,6 @@ const useStyles = makeStyles((theme) => ({
     borderRadius: theme.shape.borderRadius,
     marginTop: 49,
     fontSize: 16,
-    backgroundColor: '#3a8dff',
     fontWeight: 'bold',
   },
 }));

--- a/client/src/pages/Login/useStyles.ts
+++ b/client/src/pages/Login/useStyles.ts
@@ -12,14 +12,12 @@ const useStyles = makeStyles(() => ({
     alignItems: 'flex-start',
     justifyContent: 'space-between',
     flexDirection: 'column',
-    minHeight: '100vh',
-    paddingTop: 23,
   },
   welcome: {
-    fontSize: 26,
+    fontSize: 32,
     paddingBottom: 20,
     color: '#000000',
-    fontWeight: 700,
+    fontWeight: 900,
     fontFamily: "'Open Sans'",
   },
 }));

--- a/client/src/pages/Login/useStyles.ts
+++ b/client/src/pages/Login/useStyles.ts
@@ -7,10 +7,12 @@ const useStyles = makeStyles(() => ({
       borderBottom: '1.2px solid rgba(0, 0, 0, 0.2)',
     },
   },
-  authWrapper: {
+  wrapper: {
+    height: '80vh',
+    minHeight: '40rem',
     display: 'flex',
-    alignItems: 'flex-start',
-    justifyContent: 'space-between',
+    alignItems: 'center',
+    justifyContent: 'start',
     flexDirection: 'column',
   },
   welcome: {

--- a/client/src/pages/Login/useStyles.ts
+++ b/client/src/pages/Login/useStyles.ts
@@ -18,7 +18,6 @@ const useStyles = makeStyles(() => ({
   welcome: {
     fontSize: 32,
     paddingBottom: 20,
-    color: '#000000',
     fontWeight: 900,
     fontFamily: "'Open Sans'",
   },

--- a/client/src/pages/SignUp/SignUp.tsx
+++ b/client/src/pages/SignUp/SignUp.tsx
@@ -39,15 +39,12 @@ export default function Register(): JSX.Element {
   return (
     <Grid container component="main" className={classes.root} justify="center" alignItems="center">
       <CssBaseline />
-      <Grid item xs={12} sm={8} md={7} elevation={6} component={Paper} style={{ height: '80vh', minHeight: '40rem' }}>
-        <Box className={classes.authWrapper}>
-          <Box width="100%" maxWidth={450} p={3} alignSelf="center">
-            <Grid container justify="center" alignItems="center">
-              <Typography className={classes.title}>Sign Up</Typography>
-            </Grid>
-            <SignUpForm handleSubmit={handleSubmit} />
-          </Box>
-          <Box p={1} alignSelf="center" />
+      <Grid item xs={12} sm={8} md={7} elevation={6} component={Paper} className={classes.wrapper}>
+        <Box width="100%" maxWidth={450} p={3} mt={5}>
+          <Grid container justify="center" alignItems="center">
+            <Typography className={classes.title}>Sign Up</Typography>
+          </Grid>
+          <SignUpForm handleSubmit={handleSubmit} />
         </Box>
       </Grid>
     </Grid>

--- a/client/src/pages/SignUp/SignUp.tsx
+++ b/client/src/pages/SignUp/SignUp.tsx
@@ -7,7 +7,6 @@ import Typography from '@material-ui/core/Typography';
 import useStyles from './useStyles';
 import register from '../../helpers/APICalls/register';
 import SignUpForm from './SignUpForm/SignUpForm';
-import AuthHeader from '../../components/AuthHeader/AuthHeader';
 import { useAuth } from '../../context/useAuthContext';
 import { useSnackBar } from '../../context/useSnackbarContext';
 
@@ -38,18 +37,13 @@ export default function Register(): JSX.Element {
   };
 
   return (
-    <Grid container component="main" className={classes.root}>
+    <Grid container component="main" className={classes.root} justify="center" alignItems="center">
       <CssBaseline />
-      <Grid item xs={12} sm={8} md={7} elevation={6} component={Paper} square>
+      <Grid item xs={12} sm={8} md={7} elevation={6} component={Paper} style={{ height: '80vh', minHeight: '40rem' }}>
         <Box className={classes.authWrapper}>
-          <AuthHeader linkTo="/login" asideText="Already have an account?" btnText="Login" />
           <Box width="100%" maxWidth={450} p={3} alignSelf="center">
-            <Grid container>
-              <Grid item xs>
-                <Typography className={classes.welcome} component="h1" variant="h5">
-                  Create an account
-                </Typography>
-              </Grid>
+            <Grid container justify="center" alignItems="center">
+              <Typography className={classes.title}>Sign Up</Typography>
             </Grid>
             <SignUpForm handleSubmit={handleSubmit} />
           </Box>

--- a/client/src/pages/SignUp/SignUp.tsx
+++ b/client/src/pages/SignUp/SignUp.tsx
@@ -42,7 +42,9 @@ export default function Register(): JSX.Element {
       <Grid item xs={12} sm={8} md={7} elevation={6} component={Paper} className={classes.wrapper}>
         <Box width="100%" maxWidth={450} p={3} mt={5}>
           <Grid container justify="center" alignItems="center">
-            <Typography className={classes.title}>Sign Up</Typography>
+            <Typography className={classes.title} color="textPrimary">
+              Sign Up
+            </Typography>
           </Grid>
           <SignUpForm handleSubmit={handleSubmit} />
         </Box>

--- a/client/src/pages/SignUp/SignUpForm/SignUpForm.tsx
+++ b/client/src/pages/SignUp/SignUpForm/SignUpForm.tsx
@@ -5,7 +5,8 @@ import { Formik, FormikHelpers } from 'formik';
 import * as Yup from 'yup';
 import Typography from '@material-ui/core/Typography';
 import useStyles from './useStyles';
-import { CircularProgress } from '@material-ui/core';
+import { CircularProgress, InputLabel } from '@material-ui/core';
+import { NavLink } from 'react-router-dom';
 
 interface Props {
   handleSubmit: (
@@ -51,9 +52,11 @@ const SignUpForm = ({ handleSubmit }: Props): JSX.Element => {
     >
       {({ handleSubmit, handleChange, values, touched, errors, isSubmitting }) => (
         <form onSubmit={handleSubmit} className={classes.form} noValidate>
+          <InputLabel htmlFor="username">
+            <Typography className={classes.label}>NAME</Typography>
+          </InputLabel>
           <TextField
             id="username"
-            label={<Typography className={classes.label}>Username</Typography>}
             fullWidth
             margin="normal"
             InputLabelProps={{
@@ -68,11 +71,15 @@ const SignUpForm = ({ handleSubmit }: Props): JSX.Element => {
             helperText={touched.username ? errors.username : ''}
             error={touched.username && Boolean(errors.username)}
             value={values.username}
+            placeholder="Your name"
+            variant="outlined"
             onChange={handleChange}
           />
+          <InputLabel htmlFor="email">
+            <Typography className={classes.label}>EMAIL ADDRESS</Typography>
+          </InputLabel>
           <TextField
             id="email"
-            label={<Typography className={classes.label}>E-mail address</Typography>}
             fullWidth
             margin="normal"
             InputLabelProps={{
@@ -86,11 +93,15 @@ const SignUpForm = ({ handleSubmit }: Props): JSX.Element => {
             helperText={touched.email ? errors.email : ''}
             error={touched.email && Boolean(errors.email)}
             value={values.email}
+            placeholder="Your email"
+            variant="outlined"
             onChange={handleChange}
           />
+          <InputLabel htmlFor="password">
+            <Typography className={classes.label}>PASSWORD</Typography>
+          </InputLabel>
           <TextField
             id="password"
-            label={<Typography className={classes.label}>Password</Typography>}
             fullWidth
             margin="normal"
             InputLabelProps={{
@@ -104,13 +115,21 @@ const SignUpForm = ({ handleSubmit }: Props): JSX.Element => {
             helperText={touched.password ? errors.password : ''}
             error={touched.password && Boolean(errors.password)}
             value={values.password}
+            placeholder="Create a password"
+            variant="outlined"
             onChange={handleChange}
           />
 
           <Box textAlign="center">
-            <Button type="submit" size="large" variant="contained" color="primary" className={classes.submit}>
+            <Button type="submit" size="large" variant="contained" color="secondary" className={classes.submit}>
               {isSubmitting ? <CircularProgress style={{ color: 'white' }} /> : 'Create'}
             </Button>
+          </Box>
+          <Box mt={3} style={{ display: 'flex' }} textAlign="center" alignItems="center" justifyContent="center">
+            <Typography style={{ fontWeight: 'bold' }}>Already a member?&nbsp;</Typography>
+            <NavLink to="/login" color="secondary">
+              <Typography color="secondary">Login</Typography>
+            </NavLink>
           </Box>
         </form>
       )}

--- a/client/src/pages/SignUp/SignUpForm/SignUpForm.tsx
+++ b/client/src/pages/SignUp/SignUpForm/SignUpForm.tsx
@@ -53,7 +53,9 @@ const SignUpForm = ({ handleSubmit }: Props): JSX.Element => {
       {({ handleSubmit, handleChange, values, touched, errors, isSubmitting }) => (
         <form onSubmit={handleSubmit} className={classes.form} noValidate>
           <InputLabel htmlFor="username">
-            <Typography className={classes.label}>NAME</Typography>
+            <Typography className={classes.label} color="textPrimary">
+              name
+            </Typography>
           </InputLabel>
           <TextField
             id="username"
@@ -76,7 +78,9 @@ const SignUpForm = ({ handleSubmit }: Props): JSX.Element => {
             onChange={handleChange}
           />
           <InputLabel htmlFor="email">
-            <Typography className={classes.label}>EMAIL ADDRESS</Typography>
+            <Typography className={classes.label} color="textPrimary">
+              email address
+            </Typography>
           </InputLabel>
           <TextField
             id="email"
@@ -98,7 +102,9 @@ const SignUpForm = ({ handleSubmit }: Props): JSX.Element => {
             onChange={handleChange}
           />
           <InputLabel htmlFor="password">
-            <Typography className={classes.label}>PASSWORD</Typography>
+            <Typography className={classes.label} color="textPrimary">
+              password
+            </Typography>
           </InputLabel>
           <TextField
             id="password"
@@ -122,11 +128,13 @@ const SignUpForm = ({ handleSubmit }: Props): JSX.Element => {
 
           <Box textAlign="center">
             <Button type="submit" size="large" variant="contained" color="secondary" className={classes.submit}>
-              {isSubmitting ? <CircularProgress style={{ color: 'white' }} /> : 'Create'}
+              {isSubmitting ? <CircularProgress className={classes.circleColor} /> : 'Create'}
             </Button>
           </Box>
-          <Box mt={3} style={{ display: 'flex' }} textAlign="center" alignItems="center" justifyContent="center">
-            <Typography style={{ fontWeight: 'bold' }}>Already a member?&nbsp;</Typography>
+          <Box mt={3} display="flex" textAlign="center" alignItems="center" justifyContent="center">
+            <Typography className={classes.boldText} color="textPrimary">
+              Already a member?&nbsp;
+            </Typography>
             <NavLink to="/login" color="secondary">
               <Typography color="secondary">Login</Typography>
             </NavLink>

--- a/client/src/pages/SignUp/SignUpForm/useStyles.ts
+++ b/client/src/pages/SignUp/SignUpForm/useStyles.ts
@@ -6,17 +6,13 @@ const useStyles = makeStyles((theme) => ({
     marginTop: theme.spacing(1),
   },
   label: {
+    textTransform: 'uppercase',
     position: 'relative',
     top: '1rem',
-    color: 'rgb(0,0,0)',
     fontWeight: 900,
   },
   inputs: {
     height: '1rem',
-  },
-  forgot: {
-    paddingRight: 10,
-    color: '#3a8dff',
   },
   submit: {
     margin: theme.spacing(3, 2, 2),
@@ -27,6 +23,12 @@ const useStyles = makeStyles((theme) => ({
     marginTop: 49,
     fontSize: 16,
     fontWeight: 'bold',
+  },
+  boldText: {
+    fontWeight: 'bold',
+  },
+  circleColor: {
+    color: 'white',
   },
 }));
 

--- a/client/src/pages/SignUp/SignUpForm/useStyles.ts
+++ b/client/src/pages/SignUp/SignUpForm/useStyles.ts
@@ -6,14 +6,13 @@ const useStyles = makeStyles((theme) => ({
     marginTop: theme.spacing(1),
   },
   label: {
-    fontSize: 19,
-    color: 'rgb(0,0,0,0.4)',
-    paddingLeft: '5px',
+    position: 'relative',
+    top: '1rem',
+    color: 'rgb(0,0,0)',
+    fontWeight: 900,
   },
   inputs: {
-    marginTop: '.8rem',
-    height: '2rem',
-    padding: '5px',
+    height: '1rem',
   },
   forgot: {
     paddingRight: 10,
@@ -27,7 +26,6 @@ const useStyles = makeStyles((theme) => ({
     borderRadius: theme.shape.borderRadius,
     marginTop: 49,
     fontSize: 16,
-    backgroundColor: '#3a8dff',
     fontWeight: 'bold',
   },
 }));

--- a/client/src/pages/SignUp/useStyles.ts
+++ b/client/src/pages/SignUp/useStyles.ts
@@ -8,10 +8,12 @@ const useStyles = makeStyles(() => ({
       borderBottom: '1.2px solid rgba(0, 0, 0, 0.2)',
     },
   },
-  authWrapper: {
+  wrapper: {
+    height: '80vh',
+    minHeight: '40rem',
     display: 'flex',
-    alignItems: 'flex-start',
-    justifyContent: 'space-between',
+    alignItems: 'center',
+    justifyContent: 'start',
     flexDirection: 'column',
   },
   title: {

--- a/client/src/pages/SignUp/useStyles.ts
+++ b/client/src/pages/SignUp/useStyles.ts
@@ -19,9 +19,8 @@ const useStyles = makeStyles(() => ({
   title: {
     fontSize: 32,
     paddingBottom: 20,
-    color: '#000000',
     fontWeight: 900,
-    fontFamily: theme.typography.fontFamily,
+    fontFamily: "'Open Sans'",
   },
 }));
 

--- a/client/src/pages/SignUp/useStyles.ts
+++ b/client/src/pages/SignUp/useStyles.ts
@@ -1,4 +1,5 @@
 import { makeStyles } from '@material-ui/core/styles';
+import { theme } from '../../themes/theme';
 
 const useStyles = makeStyles(() => ({
   root: {
@@ -12,15 +13,13 @@ const useStyles = makeStyles(() => ({
     alignItems: 'flex-start',
     justifyContent: 'space-between',
     flexDirection: 'column',
-    minHeight: '100vh',
-    paddingTop: 23,
   },
-  welcome: {
-    fontSize: 26,
+  title: {
+    fontSize: 32,
     paddingBottom: 20,
     color: '#000000',
-    fontWeight: 700,
-    fontFamily: "'Open Sans'",
+    fontWeight: 900,
+    fontFamily: theme.typography.fontFamily,
   },
 }));
 


### PR DESCRIPTION
### What this PR does:
- Implement login and signup page according to UI mock.

### Screenshots / Videos:
- Login page Desktop view.

![image](https://user-images.githubusercontent.com/60498899/138190443-dfb7742e-3b41-43c1-a080-0c5dc350dcbf.png)

- Signup page Desktop view.

![image](https://user-images.githubusercontent.com/60498899/138190506-d0242240-089b-49a8-9f70-5c960f670aee.png)

- Login page Mobile view.

![image](https://user-images.githubusercontent.com/60498899/138190587-d0dda9a0-2a1c-4e76-b4f4-95c68664c01b.png)

- Signup page Mobile view.

![image](https://user-images.githubusercontent.com/60498899/138190626-905ffb56-e8d4-4c9e-99ac-fa31856dd97b.png)

### Any information needed to test this feature (required):
- Run `npm start` in the client folder to view the login/signup pages.

closes #26 


