### PR TITLE
Hotfix: Fix bugs, fetch data and add pending references in the sitters' detail page

### DIFF
--- a/client/src/components/ProfileMenu/ProfileMenu.tsx
+++ b/client/src/components/ProfileMenu/ProfileMenu.tsx
@@ -17,7 +17,6 @@ export default function ProfileMenu(): JSX.Element {
         <NavLink activeClassName={classes.active} className={classes.link} to="/profile/photo">
           Profile photo
         </NavLink>
-        {console.log(loggedInUser)}
         {loggedInUser.isSitter && (
           <NavLink activeClassName={classes.active} className={classes.link} to="/profile/availability">
             Availability

--- a/client/src/components/ProfileMenu/ProfileMenu.tsx
+++ b/client/src/components/ProfileMenu/ProfileMenu.tsx
@@ -7,7 +7,7 @@ export default function ProfileMenu(): JSX.Element {
   const classes = useStyles();
 
   const { loggedInUser } = useAuth();
-
+  if (!loggedInUser) return <></>;
   return (
     <Box>
       <Grid item className={classes.menu}>
@@ -17,7 +17,8 @@ export default function ProfileMenu(): JSX.Element {
         <NavLink activeClassName={classes.active} className={classes.link} to="/profile/photo">
           Profile photo
         </NavLink>
-        {loggedInUser?.isSitter && (
+        {console.log(loggedInUser)}
+        {loggedInUser.isSitter && (
           <NavLink activeClassName={classes.active} className={classes.link} to="/profile/availability">
             Availability
           </NavLink>

--- a/client/src/helpers/APICalls/profile.ts
+++ b/client/src/helpers/APICalls/profile.ts
@@ -1,13 +1,25 @@
 import { FetchOptions } from '../../interface/FetchOptions';
 import { Profile } from '../../interface/Profile';
+import { Review } from '../../interface/Review';
 
-export async function getSitterProfile(sitterId?: string): Promise<Profile> {
+export async function getSitterProfile(userId?: string): Promise<Profile> {
   const fetchOptions: FetchOptions = {
     method: 'GET',
     credentials: 'include',
   };
 
-  return await fetch(`/profile/${sitterId}`, fetchOptions)
+  return await fetch(`/profile/${userId}`, fetchOptions)
+    .then((res) => res.json())
+    .catch(() => ({ error: { message: 'Unable to connect to server. Please try again' } }));
+}
+
+export async function getSitterReviews(profileId?: string): Promise<Review[]> {
+  const fetchOptions: FetchOptions = {
+    method: 'GET',
+    credentials: 'include',
+  };
+
+  return await fetch(`/reviews/${profileId}`, fetchOptions)
     .then((res) => res.json())
     .catch(() => ({ error: { message: 'Unable to connect to server. Please try again' } }));
 }

--- a/client/src/helpers/APICalls/requests.ts
+++ b/client/src/helpers/APICalls/requests.ts
@@ -16,13 +16,13 @@ export async function createRequest(
   sitterId: string,
   startDate: Date,
   endDate: Date,
-  serviceType?: string,
   totalPrice?: number,
+  serviceType?: string,
 ): Promise<RequestApiData> {
   const fetchOptions: FetchOptions = {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ sitterId, startDate, endDate, serviceType, totalPrice }),
+    body: JSON.stringify({ sitterId, startDate, endDate, totalPrice, serviceType }),
     credentials: 'include',
   };
   return await fetch('/request/', fetchOptions)

--- a/client/src/interface/Profile.ts
+++ b/client/src/interface/Profile.ts
@@ -11,7 +11,7 @@ export interface Profile {
     availability: AvailabilityInDays;
     available: boolean;
     user: string;
-    ratePerHour: number;
+    ratePerDay: number;
   };
 }
 

--- a/client/src/interface/Profile.ts
+++ b/client/src/interface/Profile.ts
@@ -11,6 +11,7 @@ export interface Profile {
     availability: AvailabilityInDays;
     available: boolean;
     user: string;
+    ratePerHour: number;
   };
 }
 

--- a/client/src/interface/Review.ts
+++ b/client/src/interface/Review.ts
@@ -1,0 +1,18 @@
+import { Profile } from './profile/Profile';
+
+export interface Review {
+  reviewerProfileId: Profile;
+  reviewedProfileId: Profile;
+  requestId: Request;
+  starRating: number;
+  text: string;
+}
+
+export interface ReviewDataSuccess {
+  reviews: Review[];
+}
+
+export interface ReviewsApiData {
+  error?: { message: string };
+  success?: ReviewDataSuccess;
+}

--- a/client/src/pages/Booking/Booking.tsx
+++ b/client/src/pages/Booking/Booking.tsx
@@ -3,7 +3,7 @@ import { useState, useEffect } from 'react';
 import { DatePicker, Day, MuiPickersUtilsProvider } from '@material-ui/pickers';
 import { MaterialUiPickersDate } from '@material-ui/pickers/typings/date';
 import { MuiThemeProvider } from '@material-ui/core';
-import { createMuiTheme } from '@material-ui/core';
+import { createTheme } from '@material-ui/core';
 import { isPast, isWithinInterval, isFuture, eachDayOfInterval, getDate, getMonth } from 'date-fns';
 import DateFnsUtils from '@date-io/date-fns';
 import Grid from '@material-ui/core/Grid';
@@ -21,7 +21,7 @@ import AlertTitle from '@material-ui/lab/AlertTitle';
 interface RequestsPerMonth {
   [key: number]: Array<number>;
 }
-const materialTheme = createMuiTheme({
+const materialTheme = createTheme({
   overrides: {
     MuiPickersCalendarHeader: {
       switchHeader: {

--- a/client/src/pages/ProfileList/List.tsx
+++ b/client/src/pages/ProfileList/List.tsx
@@ -122,7 +122,7 @@ export default function List(): JSX.Element {
                         <Typography className={classes.location}>{placeholder.location}</Typography>
                       </Grid>
                       <Grid item>
-                        <Typography className={classes.price}>${placeholder.price}/hr</Typography>
+                        <Typography className={classes.price}>${placeholder.price}/day</Typography>
                       </Grid>
                     </Grid>
                   </Card>

--- a/client/src/pages/SitterDetails/SitterDetails.tsx
+++ b/client/src/pages/SitterDetails/SitterDetails.tsx
@@ -165,7 +165,7 @@ function SitterDetails(): JSX.Element {
           <Card className={classes.request}>
             <Box>
               <Typography variant="h6" align="center" className={classes.title}>
-                {profile?.ratePerHour}/hr
+                {profile?.ratePerDay}/day
               </Typography>
               {ratings !== undefined && (
                 <Rating name="size-large" defaultValue={ratings} size="large" className={classes.rating} readOnly />

--- a/client/src/pages/SitterDetails/SitterDetails.tsx
+++ b/client/src/pages/SitterDetails/SitterDetails.tsx
@@ -13,11 +13,13 @@ import {
   Typography,
   CardActionArea,
   CircularProgress,
+  InputAdornment,
 } from '@material-ui/core';
 import LocationOnIcon from '@material-ui/icons/LocationOn';
+import CalendarTodayIcon from '@material-ui/icons/CalendarToday';
 import Rating from '@material-ui/lab/Rating';
 
-import { TimePicker, KeyboardDatePicker, MuiPickersUtilsProvider } from '@material-ui/pickers';
+import { TimePicker, DatePicker, MuiPickersUtilsProvider } from '@material-ui/pickers';
 import DateFnsUtils from '@date-io/date-fns';
 
 import dog from '../../images/shiba-inu.jpeg';
@@ -144,12 +146,11 @@ function SitterDetails(): JSX.Element {
         <Grid item xs={12} sm={5}>
           <Card className={classes.request}>
             <Box>
-              {/* TODO: Add rate to the Profile Model, adjust to profile.rate. */}
               <Typography variant="h6" align="center" className={classes.title}>
-                $14/hr
+                {profile?.ratePerHour}/hr
               </Typography>
               {/* TODO: Create Rating Model and add the value. */}
-              <Rating name="size-large" defaultValue={4} size="large" className={classes.rating} readOnly />
+              <Rating name="size-large" defaultValue={0} size="large" className={classes.rating} readOnly />
             </Box>
             <Formik
               initialValues={{
@@ -165,14 +166,20 @@ function SitterDetails(): JSX.Element {
                   <Box className={classes.datesBox}>
                     <Typography className={classes.datesTitle}>drop in</Typography>
                     <MuiPickersUtilsProvider utils={DateFnsUtils}>
-                      <KeyboardDatePicker
+                      <DatePicker
                         autoOk
                         disablePast
                         variant="inline"
                         inputVariant="outlined"
                         format="dd MMMM yyyy"
                         value={values.dropInDate}
-                        InputAdornmentProps={{ position: 'start' }}
+                        InputProps={{
+                          startAdornment: (
+                            <InputAdornment position="start">
+                              <CalendarTodayIcon />
+                            </InputAdornment>
+                          ),
+                        }}
                         onChange={(date: MaterialUiPickersDate) => setFieldValue('dropInDate', date)}
                       />
                       <TimePicker
@@ -187,7 +194,7 @@ function SitterDetails(): JSX.Element {
                   <Box className={classes.datesBox}>
                     <Typography className={classes.datesTitle}>drop off</Typography>
                     <MuiPickersUtilsProvider utils={DateFnsUtils}>
-                      <KeyboardDatePicker
+                      <DatePicker
                         autoOk
                         disablePast
                         variant="inline"
@@ -195,7 +202,13 @@ function SitterDetails(): JSX.Element {
                         label=""
                         format="dd MMMM yyyy"
                         value={values.dropOffDate}
-                        InputAdornmentProps={{ position: 'start' }}
+                        InputProps={{
+                          startAdornment: (
+                            <InputAdornment position="start">
+                              <CalendarTodayIcon />
+                            </InputAdornment>
+                          ),
+                        }}
                         onChange={(date: MaterialUiPickersDate) => setFieldValue('dropOffDate', date)}
                       />
                       <TimePicker

--- a/client/src/pages/SitterDetails/SitterDetails.tsx
+++ b/client/src/pages/SitterDetails/SitterDetails.tsx
@@ -79,17 +79,18 @@ function SitterDetails(): JSX.Element {
         return;
       }
       setReviews(reviewsData?.success?.reviews);
-
-      if (reviews?.length) {
-        const startRatings = reviews?.map((review) => review?.starRating);
-        const ratingAvg =
-          startRatings?.reduce((prev, current) => Number(prev) + Number(current), 0) / startRatings.length;
-        setRatings(ratingAvg);
-      }
     }
 
     getSitterDetails();
-  }, [selectedSitterId, reviews]);
+  }, [selectedSitterId]);
+
+  useEffect(() => {
+    if (reviews?.length) {
+      const starRatings = reviews?.map((review) => review?.starRating);
+      const ratingAvg = starRatings?.reduce((prev, current) => Number(prev) + Number(current), 0) / starRatings.length;
+      setRatings(ratingAvg);
+    }
+  }, [reviews]);
 
   const profile = sitterDetails?.profile;
 

--- a/client/src/pages/SitterDetails/SitterDetails.tsx
+++ b/client/src/pages/SitterDetails/SitterDetails.tsx
@@ -29,7 +29,7 @@ import useStyles from './useStyles';
 import { useParams } from 'react-router-dom';
 import { Profile } from '../../interface/Profile';
 import { getSitterProfile, getSitterReviews } from '../../helpers/APICalls/profile';
-import { format, formatISO, parseISO } from 'date-fns';
+import { eachDayOfInterval, format, formatISO, parseISO } from 'date-fns';
 import { createRequest } from '../../helpers/APICalls/requests';
 import { MaterialUiPickersDate } from '@material-ui/pickers/typings/date';
 import { useSnackBar } from '../../context/useSnackbarContext';
@@ -102,7 +102,14 @@ function SitterDetails(): JSX.Element {
     const endDate = convertToDateTime(dropOffDate, dropOffTime);
     const selectedUserSitterId = profile?.user || '';
 
-    createRequest(selectedUserSitterId, startDate, endDate).then((data) => {
+    const numberOfDays = eachDayOfInterval({
+      start: startDate,
+      end: endDate,
+    }).length;
+
+    const totalPrice = profile?.ratePerDay ? numberOfDays * Number(profile?.ratePerDay) : numberOfDays * 40;
+
+    createRequest(selectedUserSitterId, startDate, endDate, totalPrice).then((data) => {
       if (data.error) {
         console.error({ error: data.error.message });
         updateSnackBarMessage('Please log in and try again!');

--- a/server/controllers/profile.js
+++ b/server/controllers/profile.js
@@ -17,7 +17,7 @@ exports.post = asyncHandler(async (req, res) => {
     availability,
     available,
     image,
-    ratePerHour,
+    ratePerDay,
   } = req.body;
   if (!firstName || !lastName || !id) {
     res.status(400);
@@ -36,7 +36,7 @@ exports.post = asyncHandler(async (req, res) => {
     availability,
     available,
     image,
-    ratePerHour,
+    ratePerDay,
   });
   res.status(201).json({ profile });
 });
@@ -52,7 +52,7 @@ exports.patch = asyncHandler(async (req, res) => {
     description,
     availability,
     available,
-    ratePerHour,
+    ratePerDay,
   } = req.body;
   const id = req.user.id;
   const idExists = await Profile.findOne({ user: id });
@@ -70,7 +70,7 @@ exports.patch = asyncHandler(async (req, res) => {
         description,
         availability,
         available,
-        ratePerHour,
+        ratePerDay,
       }
     );
     res.status(200).json({ update: update });

--- a/server/controllers/profile.js
+++ b/server/controllers/profile.js
@@ -17,6 +17,7 @@ exports.post = asyncHandler(async (req, res) => {
     availability,
     available,
     image,
+    ratePerHour,
   } = req.body;
   if (!firstName || !lastName || !id) {
     res.status(400);
@@ -35,6 +36,7 @@ exports.post = asyncHandler(async (req, res) => {
     availability,
     available,
     image,
+    ratePerHour,
   });
   res.status(201).json({ profile });
 });
@@ -50,6 +52,7 @@ exports.patch = asyncHandler(async (req, res) => {
     description,
     availability,
     available,
+    ratePerHour,
   } = req.body;
   const id = req.user.id;
   const idExists = await Profile.findOne({ user: id });
@@ -67,6 +70,7 @@ exports.patch = asyncHandler(async (req, res) => {
         description,
         availability,
         available,
+        ratePerHour,
       }
     );
     res.status(200).json({ update: update });
@@ -77,7 +81,7 @@ exports.patch = asyncHandler(async (req, res) => {
 });
 
 exports.get = asyncHandler(async (req, res) => {
-  const id = req.user.id;
+  const id = req.params.id || req.user.id;
   let profile;
   if (id) {
     profile = await Profile.findOne({ user: id });
@@ -86,21 +90,6 @@ exports.get = asyncHandler(async (req, res) => {
   if (!id) {
     res.status(404);
     throw new Error("No user found");
-  }
-  res.status(200).json({ profile: profile });
-});
-
-exports.getSittersProfile = asyncHandler(async (req, res) => {
-  const sitterId = req.params.id;
-
-  let profile;
-  if (sitterId) {
-    profile = await Profile.findById(sitterId);
-  }
-
-  if (!sitterId) {
-    res.status(404);
-    throw new Error("No sitter found");
   }
   res.status(200).json({ profile: profile });
 });

--- a/server/models/Profile.js
+++ b/server/models/Profile.js
@@ -74,10 +74,10 @@ const profileSchema = new mongoose.Schema({
     type: Boolean,
     default: false,
   },
-  ratePerHour: {
+  ratePerDay: {
     type: Number,
     required: true,
-    default: 14,
+    default: 40,
   },
 });
 

--- a/server/models/Profile.js
+++ b/server/models/Profile.js
@@ -74,6 +74,11 @@ const profileSchema = new mongoose.Schema({
     type: Boolean,
     default: false,
   },
+  ratePerHour: {
+    type: Number,
+    required: true,
+    default: 14,
+  },
 });
 
 module.exports = Profile = mongoose.model("Profile", profileSchema);

--- a/server/routes/profile.js
+++ b/server/routes/profile.js
@@ -1,19 +1,13 @@
 const express = require("express");
 const router = express.Router();
 const protect = require("../middleware/auth");
-const {
-  post,
-  patch,
-  get,
-  getSittersProfile,
-  all,
-} = require("../controllers/profile");
+const { post, patch, get, all } = require("../controllers/profile");
 const { multerUploads } = require("../middleware/multer");
 
+router.route("/").get(protect, get);
 router.route("/").post(protect, post);
 router.route("/").patch(protect, patch);
-router.route("/").get(protect, get);
-router.route("/:id").get(getSittersProfile);
-router.route("/all").get(protect, all);
+router.route("/all").get(all);
+router.route("/:id").get(get);
 
 module.exports = router;


### PR DESCRIPTION
### What this PR does (required):
- Fix the UX for the dates selection by the user, previously if a user click on the date value they were allowed to edit the date but validation errors appeared so we decided to avoid that functionality and only permit the user select a date within the calendar. 
- Create the rate per day field to a profile, and use it to populate the corresponding field in the sitters' detail page.
- Remove the duplicated function to get the profile by profileId, we were doing it with the user id so it would be easier to pass the user id of the profile owner (in this case, a sitter).
- In the booking page, change `createMuiTheme `to `createTheme` as suggested by the following message: `The declaration was marked as deprecated here. `
- Use the rating value to populate the stars rating with the average of all reviews received by the sitter.
- Include calculation of total price when sending a request taking into consideration the interval of days and rate per day.

### Screenshots / Videos (front-end only):
https://user-images.githubusercontent.com/29843870/140404480-d2d28a7d-f9ae-49ee-af5a-5107c748dbdd.mov
