### PR TITLE
Fix booking page refactor: Implement views for owner and sitters #97

### DIFF
--- a/client/src/components/BookingItem/BookingItem.tsx
+++ b/client/src/components/BookingItem/BookingItem.tsx
@@ -1,3 +1,8 @@
+import { useEffect, useState } from 'react';
+import { useAuth } from '../../context/useAuthContext';
+import { getSitterProfile } from '../../helpers/APICalls/profile';
+import { Profile } from '../../interface/Profile';
+import { User } from '../../interface/User';
 import NextBookingItem from './NextBookingItem';
 import OngoingAndPastBookingItem from './OngoingAndPastBookingItem';
 
@@ -5,19 +10,43 @@ interface Props {
   requestId: string;
   from: Date;
   to: Date;
+  owner: User;
+  sitter: User;
   status: string;
   upcoming?: boolean;
+  past?: boolean;
 }
 
 function BookingItem(props: Props): JSX.Element {
-  const { requestId, from, to, status, upcoming } = props;
+  const { requestId, from, to, owner, sitter, status, upcoming, past } = props;
+
+  const [profile, setProfile] = useState<Profile>();
+  const { loggedInUser } = useAuth();
+
+  useEffect(() => {
+    async function getProfile() {
+      const userProfile = await (loggedInUser?.isSitter ? getSitterProfile(owner) : getSitterProfile(sitter));
+      setProfile(userProfile);
+    }
+    getProfile();
+  }, [loggedInUser?.isSitter, owner, sitter]);
+
+  const fullName = `${profile?.profile.firstName} ${profile?.profile.lastName}`;
 
   return (
     <>
       {upcoming ? (
-        <NextBookingItem key={requestId} requestId={requestId} from={from} to={to} status={status} />
+        <NextBookingItem key={requestId} requestId={requestId} from={from} to={to} name={fullName} status={status} />
       ) : (
-        <OngoingAndPastBookingItem key={requestId} requestId={requestId} from={from} to={to} status={status} />
+        <OngoingAndPastBookingItem
+          key={requestId}
+          requestId={requestId}
+          from={from}
+          to={to}
+          name={fullName}
+          status={status}
+          past={past}
+        />
       )}
     </>
   );

--- a/client/src/components/BookingItem/BookingItem.tsx
+++ b/client/src/components/BookingItem/BookingItem.tsx
@@ -32,11 +32,20 @@ function BookingItem(props: Props): JSX.Element {
   }, [loggedInUser?.isSitter, owner, sitter]);
 
   const fullName = `${profile?.profile.firstName} ${profile?.profile.lastName}`;
+  const photo = profile?.profile.image.url;
 
   return (
     <>
       {upcoming ? (
-        <NextBookingItem key={requestId} requestId={requestId} from={from} to={to} name={fullName} status={status} />
+        <NextBookingItem
+          key={requestId}
+          requestId={requestId}
+          from={from}
+          to={to}
+          name={fullName}
+          image={photo}
+          status={status}
+        />
       ) : (
         <OngoingAndPastBookingItem
           key={requestId}
@@ -44,6 +53,7 @@ function BookingItem(props: Props): JSX.Element {
           from={from}
           to={to}
           name={fullName}
+          image={photo}
           status={status}
           past={past}
         />

--- a/client/src/components/BookingItem/BookingItem.tsx
+++ b/client/src/components/BookingItem/BookingItem.tsx
@@ -31,8 +31,8 @@ function BookingItem(props: Props): JSX.Element {
     getProfile();
   }, [loggedInUser?.isSitter, owner, sitter]);
 
-  const fullName = `${profile?.profile.firstName} ${profile?.profile.lastName}`;
-  const photo = profile?.profile.image.url;
+  const fullName = `${profile?.profile?.firstName} ${profile?.profile?.lastName}`;
+  const photo = profile?.profile?.image?.url;
 
   return (
     <>

--- a/client/src/components/BookingItem/NextBookingItem.tsx
+++ b/client/src/components/BookingItem/NextBookingItem.tsx
@@ -10,7 +10,6 @@ import Typography from '@material-ui/core/Typography';
 import SettingsIcon from '@material-ui/icons/Settings';
 import { format } from 'date-fns';
 
-import person from '../../images/women-striped-blouse.png';
 import { updateRequest } from '../../helpers/APICalls/requests';
 import useStyles from './useStyles';
 import { useAuth } from '../../context/useAuthContext';
@@ -20,6 +19,7 @@ interface Props {
   from: Date;
   to: Date;
   name: string;
+  image: string | undefined;
   status: string;
 }
 
@@ -27,7 +27,7 @@ function NextBookingItem(props: Props): JSX.Element {
   const classes = useStyles();
   const { loggedInUser } = useAuth();
 
-  const { requestId, from, to, name, status } = props;
+  const { requestId, from, to, name, image, status } = props;
 
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const [currentStatus, setCurrentStatus] = useState<string>(status);
@@ -79,8 +79,7 @@ function NextBookingItem(props: Props): JSX.Element {
           </Menu>
         </Box>
         <Box className={classes.details}>
-          {/* TODO: Change mock image to user profile photo inside props. */}
-          <Avatar aria-label="next-booking" alt="Person" src={person} className={classes.large} />
+          <Avatar aria-label="next-booking" alt="Person" src={image} className={classes.large} />
           <Typography variant="h6" color="textPrimary" display="inline">
             {name}
           </Typography>

--- a/client/src/components/BookingItem/NextBookingItem.tsx
+++ b/client/src/components/BookingItem/NextBookingItem.tsx
@@ -13,18 +13,21 @@ import { format } from 'date-fns';
 import person from '../../images/women-striped-blouse.png';
 import { updateRequest } from '../../helpers/APICalls/requests';
 import useStyles from './useStyles';
+import { useAuth } from '../../context/useAuthContext';
 
 interface Props {
   requestId: string;
   from: Date;
   to: Date;
+  name: string;
   status: string;
 }
 
 function NextBookingItem(props: Props): JSX.Element {
   const classes = useStyles();
+  const { loggedInUser } = useAuth();
 
-  const { requestId, from, to, status } = props;
+  const { requestId, from, to, name, status } = props;
 
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const [currentStatus, setCurrentStatus] = useState<string>(status);
@@ -65,9 +68,11 @@ function NextBookingItem(props: Props): JSX.Element {
           <Typography variant="h5" className={classes.pos}>
             {`${format(new Date(from), 'd MMMM yyyy')} - ${format(new Date(to), 'd MMMM yyyy')}`}
           </Typography>
-          <IconButton aria-label="more" onClick={handleClick}>
-            <SettingsIcon />
-          </IconButton>
+          {loggedInUser?.isSitter && (
+            <IconButton aria-label="more" onClick={handleClick}>
+              <SettingsIcon />
+            </IconButton>
+          )}
           <Menu id="settings" anchorEl={anchorEl} keepMounted open={open} onClose={handleClose} elevation={0}>
             <MenuItem onClick={handleAccept}>Accept</MenuItem>
             <MenuItem onClick={handleDecline}>Decline</MenuItem>
@@ -76,11 +81,13 @@ function NextBookingItem(props: Props): JSX.Element {
         <Box className={classes.details}>
           {/* TODO: Change mock image to user profile photo inside props. */}
           <Avatar aria-label="next-booking" alt="Person" src={person} className={classes.large} />
-          {/* TODO: Change hardcoded name to user name inside props. */}
           <Typography variant="h6" color="textPrimary" display="inline">
-            Norma Byers
+            {name}
           </Typography>
         </Box>
+        <Typography color="textSecondary" align="right">
+          {currentStatus}
+        </Typography>
       </CardContent>
     </>
   );

--- a/client/src/components/BookingItem/OngoingAndPastBookingItem.tsx
+++ b/client/src/components/BookingItem/OngoingAndPastBookingItem.tsx
@@ -15,18 +15,22 @@ import { format } from 'date-fns';
 import person from '../../images/women-striped-blouse.png';
 import { updateRequest } from '../../helpers/APICalls/requests';
 import useStyles from './useStyles';
+import { useAuth } from '../../context/useAuthContext';
 
 interface Props {
   requestId: string;
   from: Date;
   to: Date;
+  name: string;
   status: string;
+  past?: boolean;
 }
 
 function OngoingAndPastBookingItem(props: Props): JSX.Element {
   const classes = useStyles();
+  const { loggedInUser } = useAuth();
 
-  const { requestId, from, to, status } = props;
+  const { requestId, from, to, name, status, past } = props;
 
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const [currentStatus, setCurrentStatus] = useState<string>(status);
@@ -66,15 +70,18 @@ function OngoingAndPastBookingItem(props: Props): JSX.Element {
         <Paper variant="outlined" square>
           <CardHeader
             action={
-              <>
-                <IconButton aria-label="more" onClick={handleClick}>
-                  <SettingsIcon />
-                </IconButton>
-                <Menu anchorEl={anchorEl} keepMounted open={open} onClose={handleClose} elevation={0}>
-                  <MenuItem onClick={handleAccept}>Accept</MenuItem>
-                  <MenuItem onClick={handleDecline}>Decline</MenuItem>
-                </Menu>
-              </>
+              loggedInUser?.isSitter &&
+              !past && (
+                <>
+                  <IconButton aria-label="more" onClick={handleClick}>
+                    <SettingsIcon />
+                  </IconButton>
+                  <Menu anchorEl={anchorEl} keepMounted open={open} onClose={handleClose} elevation={0}>
+                    <MenuItem onClick={handleAccept}>Accept</MenuItem>
+                    <MenuItem onClick={handleDecline}>Decline</MenuItem>
+                  </Menu>
+                </>
+              )
             }
             title={`${format(new Date(from), 'd MMMM yyyy')} - ${format(new Date(to), 'd MMMM yyyy')}`}
             disableTypography
@@ -86,9 +93,8 @@ function OngoingAndPastBookingItem(props: Props): JSX.Element {
             <Box className={classes.details}>
               {/* TODO: Change mock image to user profile photo inside props. */}
               <Avatar aria-label="next-booking" alt="Person" src={person} className={classes.large} />
-              {/* TODO: Change hardcoded name to user name inside props. */}
               <Typography variant="h6" color="textPrimary" display="inline">
-                Norma Byers
+                {name}
               </Typography>
             </Box>
           </CardContent>

--- a/client/src/components/BookingItem/OngoingAndPastBookingItem.tsx
+++ b/client/src/components/BookingItem/OngoingAndPastBookingItem.tsx
@@ -12,7 +12,6 @@ import Typography from '@material-ui/core/Typography';
 import SettingsIcon from '@material-ui/icons/Settings';
 import { format } from 'date-fns';
 
-import person from '../../images/women-striped-blouse.png';
 import { updateRequest } from '../../helpers/APICalls/requests';
 import useStyles from './useStyles';
 import { useAuth } from '../../context/useAuthContext';
@@ -22,6 +21,7 @@ interface Props {
   from: Date;
   to: Date;
   name: string;
+  image: string | undefined;
   status: string;
   past?: boolean;
 }
@@ -30,7 +30,7 @@ function OngoingAndPastBookingItem(props: Props): JSX.Element {
   const classes = useStyles();
   const { loggedInUser } = useAuth();
 
-  const { requestId, from, to, name, status, past } = props;
+  const { requestId, from, to, name, image, status, past } = props;
 
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const [currentStatus, setCurrentStatus] = useState<string>(status);
@@ -91,8 +91,7 @@ function OngoingAndPastBookingItem(props: Props): JSX.Element {
               {currentStatus}
             </Typography>
             <Box className={classes.details}>
-              {/* TODO: Change mock image to user profile photo inside props. */}
-              <Avatar aria-label="next-booking" alt="Person" src={person} className={classes.large} />
+              <Avatar aria-label="next-booking" alt="Person" src={image} className={classes.large} />
               <Typography variant="h6" color="textPrimary" display="inline">
                 {name}
               </Typography>

--- a/client/src/helpers/APICalls/profile.ts
+++ b/client/src/helpers/APICalls/profile.ts
@@ -1,8 +1,9 @@
 import { FetchOptions } from '../../interface/FetchOptions';
 import { Profile } from '../../interface/Profile';
 import { Review } from '../../interface/Review';
+import { User } from '../../interface/User';
 
-export async function getSitterProfile(userId?: string): Promise<Profile> {
+export async function getSitterProfile(userId?: string | User): Promise<Profile> {
   const fetchOptions: FetchOptions = {
     method: 'GET',
     credentials: 'include',

--- a/client/src/interface/Profile.ts
+++ b/client/src/interface/Profile.ts
@@ -12,6 +12,7 @@ export interface Profile {
     available: boolean;
     user: string;
     ratePerDay: number;
+    image: Image;
   };
 }
 
@@ -23,4 +24,9 @@ export interface AvailabilityInDays {
   friday: boolean;
   saturday: boolean;
   sunday: boolean;
+}
+
+interface Image {
+  url: string;
+  publicId: string;
 }

--- a/client/src/pages/Booking/Booking.tsx
+++ b/client/src/pages/Booking/Booking.tsx
@@ -17,6 +17,7 @@ import BookingItem from '../../components/BookingItem/BookingItem';
 import useStyles from './useStyles';
 import Alert from '@material-ui/lab/Alert';
 import AlertTitle from '@material-ui/lab/AlertTitle';
+import { useAuth } from '../../context/useAuthContext';
 
 interface RequestsPerMonth {
   [key: number]: Array<number>;
@@ -52,6 +53,7 @@ const materialTheme = createTheme({
 
 function Booking(): JSX.Element {
   const classes = useStyles();
+  const { loggedInUser } = useAuth();
 
   const [requests, setRequests] = useState<RequestsList>();
   const [selectedDate, setDate] = useState<MaterialUiPickersDate>(new Date());
@@ -65,18 +67,19 @@ function Booking(): JSX.Element {
     getRequestsAndSave();
   }, []);
 
-  const requestsReceived = requests?.requestsReceived;
+  const requestsToDisplay = loggedInUser?.isSitter ? requests?.requestsReceived : requests?.requestsSend;
   const today = new Date();
-  const pastBookings = requestsReceived?.filter((request) => isPast(new Date(request.endDate)));
-  const currentBookings = requestsReceived?.filter((request) =>
+  const pastBookings = requestsToDisplay?.filter((request) => isPast(new Date(request.endDate)));
+  const currentBookings = requestsToDisplay?.filter((request) =>
     isWithinInterval(today, {
       start: new Date(request.startDate),
       end: new Date(request.endDate),
     }),
   );
-  const upcomingBookings = requestsReceived?.filter((request) => isFuture(new Date(request.startDate)));
+  const upcomingBookings = requestsToDisplay?.filter((request) => isFuture(new Date(request.startDate)));
+
   const requestsDayPerMonth: RequestsPerMonth = {};
-  requestsReceived
+  requestsToDisplay
     ?.map((request) => eachDayOfInterval({ start: new Date(request.startDate), end: new Date(request.endDate) }))
     .map((interval) => {
       interval.map((date) => {
@@ -138,15 +141,22 @@ function Booking(): JSX.Element {
                     requestId={request._id}
                     from={request.startDate}
                     to={request.endDate}
+                    owner={request.owner}
+                    sitter={request.sitter}
                     status={request.status}
                     upcoming
                   />
                 ))
-              ) : (
+              ) : loggedInUser?.isSitter ? (
                 <Alert severity="info">
                   <AlertTitle>Info</AlertTitle>
                   You will not have pet visits in the near future 🔮
                   <strong className={classes.title}>be patient!</strong>
+                </Alert>
+              ) : (
+                <Alert severity="info">
+                  <AlertTitle>Info</AlertTitle>
+                  No travel plans in the near future. 🔮
                 </Alert>
               )}
             </Card>
@@ -180,13 +190,20 @@ function Booking(): JSX.Element {
                     requestId={request._id}
                     from={request.startDate}
                     to={request.endDate}
+                    owner={request.owner}
+                    sitter={request.sitter}
                     status={request.status}
                   />
                 ))
-              ) : (
+              ) : loggedInUser?.isSitter ? (
                 <Alert severity="info">
                   <AlertTitle>Info</AlertTitle>
                   You are not taking care of any pets for now 🛀 <strong className={classes.title}>relax!</strong>
+                </Alert>
+              ) : (
+                <Alert severity="info">
+                  <AlertTitle>Info</AlertTitle>
+                  Enjoy your pet today, it is time to play! 🐾
                 </Alert>
               )}
               <Typography variant="h6" className={classes.title}>
@@ -199,14 +216,22 @@ function Booking(): JSX.Element {
                     requestId={request._id}
                     from={request.startDate}
                     to={request.endDate}
+                    owner={request.owner}
+                    sitter={request.sitter}
                     status={request.status}
+                    past
                   />
                 ))
-              ) : (
+              ) : loggedInUser?.isSitter ? (
                 <Alert severity="info">
                   <AlertTitle>Info</AlertTitle>
                   Do not worry, you will be able to see your memories 🐾
                   <strong className={classes.title}>soon!</strong>
+                </Alert>
+              ) : (
+                <Alert severity="info">
+                  <AlertTitle>Info</AlertTitle>
+                  Book today, so we can have something to show you here. 🧾
                 </Alert>
               )}
             </Card>

--- a/server/controllers/auth.js
+++ b/server/controllers/auth.js
@@ -46,6 +46,7 @@ exports.registerUser = asyncHandler(async (req, res, next) => {
           username: user.username,
           email: user.email,
           stripeCustomerId,
+          isSitter: user.isSitter,
         },
       },
     });


### PR DESCRIPTION
### What this PR does (required):
Enhance the view of the bookings for sitters and owners:
- Sitters can see  owners info from the requests received, edit in order to accept or decline next and current bookings (the past bookings are read only now). 
- Owners can see sitters info from the requests sent, including info as dates, status, sitters' photo.
- If there are no requests, funny alerts will appear. They will depend if you are a sitter or owner. 
- Both have access to calendar. 

### Screenshots / Videos (front-end only):

https://user-images.githubusercontent.com/29843870/140455906-9aa38ce6-b943-4d47-8f48-c1df0f2b6ed3.mov


### Any information needed to test this feature (required):
- It is necessary to have a profile of a sitter, make a request to them. Or you can only click in the My Sitters/My Jobs button and you should be able to see some alerts. 
